### PR TITLE
Dont allow passing all service roles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners for everything in the repo.
-*       @jschaefe-akw @ak-tome @Desmonthes @tmthang @nasmi-akw
+*       @Gagarmel @ak-tome @Desmonthes @tmthang @nasmi-akw

--- a/modules/ssvc_ci_role_eks/README.md
+++ b/modules/ssvc_ci_role_eks/README.md
@@ -29,6 +29,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_state_bucket_arn"></a> [state\_bucket\_arn](#input\_state\_bucket\_arn) | n/a | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `string` | n/a | yes |
 | <a name="input_enable_eks_ci_role"></a> [enable\_eks\_ci\_role](#input\_enable\_eks\_ci\_role) | n/a | `bool` | `false` | no |
 


### PR DESCRIPTION
This pull request includes updates to the `CODEOWNERS` file, enhancements to the Terraform module for EKS CI roles, and documentation updates. The most significant changes involve adding new permissions to the IAM policy, updating the module's input variables, and modifying ownership assignments.

### Ownership Updates:
* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bL2-R2): Replaced `@jschaefe-akw` with `@Gagarmel` as a default owner for the repository.

### Terraform Module Enhancements:
* [`modules/ssvc_ci_role_eks/main.tf`](diffhunk://#diff-0bbdb4657c12e63c725f7396400be493fdbaa6fcf0d4a54af60c0f2f5c659f89R83-R99): Added a new IAM policy statement to allow the `iam:PassRole` action for specific EKS-related service roles, with a condition restricting the service to `eks.amazonaws.com`.
* [`modules/ssvc_ci_role_eks/main.tf`](diffhunk://#diff-0bbdb4657c12e63c725f7396400be493fdbaa6fcf0d4a54af60c0f2f5c659f89L112): Removed the `iam:PassRole` action from a general IAM policy statement to avoid redundancy and ensure more granular control.

### Documentation Updates:
* [`modules/ssvc_ci_role_eks/README.md`](diffhunk://#diff-608b6c571427194fdf48d32c58bd76beeecb67b6e839969df2b4ccdc3d7ffecfR32): Added a new required input variable, `state_bucket_arn`, to the module documentation.