### PR TITLE
Fix resource list

### DIFF
--- a/modules/ssvc_ci_role_eks/main.tf
+++ b/modules/ssvc_ci_role_eks/main.tf
@@ -87,8 +87,7 @@ data "aws_iam_policy_document" "ssvc_cluster_ci_role_terraform" {
       "iam:PassRole"
     ]
     resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS",
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/eks-nodegroup.amazonaws.com/AWSServiceRoleForAmazonEKSNodegroup"
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*"
     ]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
This pull request modifies the IAM policy document for the `ssvc_cluster_ci_role_terraform` resource in the `modules/ssvc_ci_role_eks/main.tf` file. The change broadens the scope of the `resources` field to allow the role to pass any IAM role in the account.

### IAM Policy Updates:
* Updated the `resources` field in the `aws_iam_policy_document` to replace specific role ARNs with a wildcard (`arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/*`), granting broader permissions for role passing.