### PR TITLE
Add GitHub Actions Management Role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ci_role"></a> [ci\_role](#module\_ci\_role) | ./modules/ci_role | n/a |
+| <a name="module_github_actions_role"></a> [github\_actions\_role](#module\_github\_actions\_role) | ./modules/github_actions_role | n/a |
 | <a name="module_ssvc_ci_role_eks"></a> [ssvc\_ci\_role\_eks](#module\_ssvc\_ci\_role\_eks) | ./modules/ssvc_ci_role_eks | n/a |
 | <a name="module_ssvc_ci_role_eks_config"></a> [ssvc\_ci\_role\_eks\_config](#module\_ssvc\_ci\_role\_eks\_config) | ./modules/ssvc_ci_role_eks_config | n/a |
 | <a name="module_state_bucket"></a> [state\_bucket](#module\_state\_bucket) | ./modules/state_bucket | n/a |
@@ -28,6 +29,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_environment"></a> [account\_environment](#input\_account\_environment) | n/a | `string` | n/a | yes |
+| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | GitHub organization name for OIDC provider | `string` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | n/a | `string` | n/a | yes |
 | <a name="input_trusted_ci_role_arn"></a> [trusted\_ci\_role\_arn](#input\_trusted\_ci\_role\_arn) | n/a | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | n/a | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-### Modules
-
 module "ci_role" {
   source               = "./modules/ci_role"
   account_environment  = var.account_environment
@@ -11,7 +9,6 @@ module "state_bucket" {
   source              = "./modules/state_bucket"
   account_environment = var.account_environment
   project_name        = var.project_name
-
 }
 
 module "ssvc_ci_role_eks_config" {
@@ -27,4 +24,11 @@ module "ssvc_ci_role_eks" {
   vpc_id             = var.vpc_id
   enable_eks_ci_role = var.enable_eks_ci_role
   state_bucket_arn   = module.state_bucket.s3_bucket_arn
+}
+
+module "github_actions_role" {
+  source = "./modules/github_actions_role"
+
+  github_organization = var.github_organization
+  state_bucket_arn    = module.state_bucket.s3_bucket_arn
 }

--- a/modules/github_actions_role/README.md
+++ b/modules/github_actions_role/README.md
@@ -1,0 +1,39 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_github_actions_role"></a> [github\_actions\_role](#module\_github\_actions\_role) | terraform-aws-modules/iam/aws//modules/iam-github-oidc-role | 5.55.0 |
+| <a name="module_github_oidc_provider"></a> [github\_oidc\_provider](#module\_github\_oidc\_provider) | terraform-aws-modules/iam/aws//modules/iam-github-oidc-provider | 5.55.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.application_role_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.application_role_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | GitHub organization name for OIDC provider | `string` | n/a | yes |
+| <a name="input_state_bucket_arn"></a> [state\_bucket\_arn](#input\_state\_bucket\_arn) | ARN of the state bucket | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/github_actions_role/main.tf
+++ b/modules/github_actions_role/main.tf
@@ -1,0 +1,82 @@
+data "aws_caller_identity" "current" {}
+
+module "github_oidc_provider" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-provider"
+  version = "5.55.0"
+}
+
+module "github_actions_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.55.0"
+
+  name = "GitHubActionsManagement"
+
+  subjects = [
+    "repo:${var.github_organization}/*",
+  ]
+
+  policies = {
+    ApplicationRoleManagement = aws_iam_policy.application_role_management.arn
+    StateBucketAccess         = var.state_bucket_arn
+  }
+}
+
+data "aws_iam_policy_document" "application_role_management" {
+  statement {
+    sid    = "AllowApplicationRoleManagement"
+    effect = "Allow"
+    actions = [
+      "iam:CreateRole",
+      "iam:DeleteRole",
+      "iam:GetRole",
+      "iam:PutRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:AttachRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:TagRole",
+      "iam:ListRoleTags",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies"
+    ]
+    resources = [
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/GitHubActionsApp*"
+    ]
+  }
+
+  statement {
+    sid    = "AllowIAMList"
+    effect = "Allow"
+    actions = [
+      "iam:List*"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "application_role_management" {
+  name        = "ApplicationRoleManagement"
+  description = "Policy for managing application IAM roles for GitHub Actions"
+  policy      = data.aws_iam_policy_document.application_role_management.json
+}
+
+data "aws_iam_policy_document" "state_bucket_access" {
+  statement {
+    sid       = "AllowListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [var.state_bucket_arn]
+  }
+
+  statement {
+    sid       = "AllowStateBucketAccess"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["${var.state_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "state_bucket_access" {
+  name        = "GitHubActionsStateBucketAccess"
+  description = "Policy to access Terraform state bucket"
+  policy      = data.aws_iam_policy_document.state_bucket_access.json
+}

--- a/modules/github_actions_role/variables.tf
+++ b/modules/github_actions_role/variables.tf
@@ -1,0 +1,9 @@
+variable "github_organization" {
+  description = "GitHub organization name for OIDC provider"
+  type        = string
+}
+
+variable "state_bucket_arn" {
+  description = "ARN of the state bucket"
+  type        = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,12 +11,12 @@ variable "vpc_id" {
 }
 
 variable "enable_eks_ci_role" {
-  type = bool
+  type    = bool
   default = true
 }
 
 variable "enable_eks_ci_config_role" {
-  type = bool
+  type    = bool
   default = true
 }
 
@@ -27,4 +27,9 @@ variable "trusted_ci_role_arn" {
 variable "trusted_ci_role_arns" {
   type    = set(string)
   default = []
+}
+
+variable "github_organization" {
+  type        = string
+  description = "GitHub organization name for OIDC provider"
 }


### PR DESCRIPTION
This pull request introduces a new module for managing GitHub Actions roles and updates the Terraform configuration to integrate it. The changes include adding a `github_actions_role` module, defining necessary variables, and updating documentation to reflect the new functionality.

### Addition of GitHub Actions Role Module:
* Added a new `github_actions_role` module to manage IAM roles and policies for GitHub Actions, including support for OIDC providers and access to the state bucket. (`modules/github_actions_role/main.tf`, `modules/github_actions_role/variables.tf`, `modules/github_actions_role/README.md`) [[1]](diffhunk://#diff-a6fbcb9b2e696dddc0745cc82be4e2b50b6cbb3f6a3213cb97eb74a014882c1aR1-R82) [[2]](diffhunk://#diff-d2f7e76a6f95ec9af568f2540566aa5f800986db11f45bdc9383567ff05bd5d0R1-R9) [[3]](diffhunk://#diff-5a0900fcf55616ebaabd7d093b432e0ba67a7e252696c7139c504b91fecaf77cR1-R39)

### Updates to Main Configuration:
* Integrated the `github_actions_role` module into the main Terraform configuration, passing required variables such as `github_organization` and `state_bucket_arn`. (`main.tf`)

### Variable and Input Updates:
* Added a new `github_organization` variable to the root module for specifying the GitHub organization name. (`variables.tf`)
* Updated the `README.md` to document the new input `github_organization` and the `github_actions_role` module. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32)

These changes enable better integration with GitHub Actions by providing a dedicated module for role and policy management.