### PR TITLE
pin module versions for IAM and S3 bucket to ensure compatibility

### DIFF
--- a/modules/ci_role/README.md
+++ b/modules/ci_role/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ssvc_ci_role"></a> [ssvc\_ci\_role](#module\_ssvc\_ci\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | n/a |
+| <a name="module_ssvc_ci_role"></a> [ssvc\_ci\_role](#module\_ssvc\_ci\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.55.0 |
 
 ## Resources
 

--- a/modules/ci_role/main.tf
+++ b/modules/ci_role/main.tf
@@ -1,7 +1,8 @@
 data "aws_caller_identity" "current" {}
 
 module "ssvc_ci_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.55.0"
 
   create_role = true
 

--- a/modules/crossplane_core_role/README.md
+++ b/modules/crossplane_core_role/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_crossplane_core_iam_role"></a> [crossplane\_core\_iam\_role](#module\_crossplane\_core\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | n/a |
+| <a name="module_crossplane_core_iam_role"></a> [crossplane\_core\_iam\_role](#module\_crossplane\_core\_iam\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.55.0 |
 
 ## Resources
 

--- a/modules/crossplane_core_role/main.tf
+++ b/modules/crossplane_core_role/main.tf
@@ -5,7 +5,8 @@
 module "crossplane_core_iam_role" {
   count = var.env == "prod" ? 1 : 0
 
-  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.55.0"
 
   create_role = true
 
@@ -13,8 +14,8 @@ module "crossplane_core_iam_role" {
   role_requires_mfa = false
 
   create_custom_role_trust_policy = true
-  custom_role_trust_policy = data.aws_iam_policy_document.order_adapter_trust_policy.json
-  
+  custom_role_trust_policy        = data.aws_iam_policy_document.order_adapter_trust_policy.json
+
   custom_role_policy_arns = [
     aws_iam_policy.order_adapter.arn
   ]

--- a/modules/ssvc_ci_role_eks/README.md
+++ b/modules/ssvc_ci_role_eks/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ssvc_ci_role_eks"></a> [ssvc\_ci\_role\_eks](#module\_ssvc\_ci\_role\_eks) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | n/a |
+| <a name="module_ssvc_ci_role_eks"></a> [ssvc\_ci\_role\_eks](#module\_ssvc\_ci\_role\_eks) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.55.0 |
 
 ## Resources
 

--- a/modules/ssvc_ci_role_eks/main.tf
+++ b/modules/ssvc_ci_role_eks/main.tf
@@ -3,14 +3,15 @@ data "aws_caller_identity" "current" {}
 module "ssvc_ci_role_eks" {
   count = (var.enable_eks_ci_role ? 1 : 0)
 
-  source = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.55.0"
 
   create_role = true
 
   role_name         = "ssvc_ci_role_eks"
   role_requires_mfa = false
 
-  trusted_role_arns = [ "arn:aws:iam::335922408564:role/ci-devsecops", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/SAML-AKW-ADMIN"]
+  trusted_role_arns = ["arn:aws:iam::335922408564:role/ci-devsecops", "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/SAML-AKW-ADMIN"]
   custom_role_policy_arns = [
     aws_iam_policy.ssvc_cluster_ci_role_terraform[0].arn,
     aws_iam_policy.ssvc_cluster_ci_role_terraform_read[0].arn
@@ -139,7 +140,7 @@ data "aws_iam_policy_document" "ssvc_cluster_ci_role_terraform" {
   }
 
   statement {
-    sid = "Autoscaling"
+    sid    = "Autoscaling"
     effect = "Allow"
     actions = [
       "autoscaling:*",

--- a/modules/ssvc_ci_role_eks_config/README.md
+++ b/modules/ssvc_ci_role_eks_config/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_this"></a> [this](#module\_this) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | ~> 5.0 |
+| <a name="module_this"></a> [this](#module\_this) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.55.0 |
 
 ## Resources
 

--- a/modules/ssvc_ci_role_eks_config/main.tf
+++ b/modules/ssvc_ci_role_eks_config/main.tf
@@ -4,7 +4,7 @@ module "this" {
   count = var.enable_eks_ci_config_role ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5.0"
+  version = "5.55.0"
 
   create_role = true
 

--- a/modules/state_bucket/README.md
+++ b/modules/state_bucket/README.md
@@ -11,7 +11,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_tf_state_bucket"></a> [tf\_state\_bucket](#module\_tf\_state\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
+| <a name="module_tf_state_bucket"></a> [tf\_state\_bucket](#module\_tf\_state\_bucket) | terraform-aws-modules/s3-bucket/aws | 4.9.0 |
 
 ## Resources
 

--- a/modules/state_bucket/main.tf
+++ b/modules/state_bucket/main.tf
@@ -1,6 +1,6 @@
 module "tf_state_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.0"
+  version = "4.9.0"
 
   bucket = "${var.project_name}-state-${var.account_environment}"
 


### PR DESCRIPTION
This pull request updates the versions of Terraform modules used across multiple components to ensure consistency and compatibility with the latest features and fixes. The changes primarily involve upgrading the `terraform-aws-modules/iam/aws` and `terraform-aws-modules/s3-bucket/aws` modules to specific newer versions.

### IAM Role Module Updates:
* Updated the version of the `terraform-aws-modules/iam/aws` module to `5.55.0` in the following components:
  - `modules/ci_role` (`README.md`, `main.tf`) [[1]](diffhunk://#diff-a52706c83d0c9d4a733b08feb18dd88fa8c7854b593fd8d25c4f8e24c2fd5b59L16-R16) [[2]](diffhunk://#diff-64f29b276997a6e45fba70ee8314e0aa3acf9a2d03b8d2a01d524fb08f046aa5R5)
  - `modules/crossplane_core_role` (`README.md`, `main.tf`) [[1]](diffhunk://#diff-1e61bc736e9a2a365d640bb6650c484b3975ebb9a5c74c6789f0a23e2942ca6dL16-R16) [[2]](diffhunk://#diff-e2ef59eca9fbef45a3ad383adba8426599be9e829f78a3010e6f75ef63575e65R9)
  - `modules/ssvc_ci_role_eks` (`README.md`, `main.tf`) [[1]](diffhunk://#diff-608b6c571427194fdf48d32c58bd76beeecb67b6e839969df2b4ccdc3d7ffecfL16-R16) [[2]](diffhunk://#diff-0bbdb4657c12e63c725f7396400be493fdbaa6fcf0d4a54af60c0f2f5c659f89R7)
  - `modules/ssvc_ci_role_eks_config` (`README.md`, `main.tf`) [[1]](diffhunk://#diff-6af2e8d519a07394a3219e6829189b2f3f34dcd2097dbc754d291eb201351ba6L16-R16) [[2]](diffhunk://#diff-62195c7fc18f6e32d90c37526cd5704d428baa22879404c871e691dda4224880L7-R7)

### S3 Bucket Module Update:
* Updated the version of the `terraform-aws-modules/s3-bucket/aws` module to `4.9.0` in the `modules/state_bucket` component (`README.md`, `main.tf`) [[1]](diffhunk://#diff-8d498636543a2cda106ad3b9e4c778bcf81ea6833579162a01e5a5488facfabfL14-R14) [[2]](diffhunk://#diff-c0cb15f8af85bd2e4fbe1b9dd40cad5418d2a6bde90937e422cd26845932b946L3-R3).