### PR TITLE
Fix bucket role assignment to use the correct IAM policy ARN

### DIFF
--- a/modules/github_actions_role/main.tf
+++ b/modules/github_actions_role/main.tf
@@ -17,7 +17,7 @@ module "github_actions_role" {
 
   policies = {
     ApplicationRoleManagement = aws_iam_policy.application_role_management.arn
-    StateBucketAccess         = var.state_bucket_arn
+    StateBucketAccess         = aws_iam_policy.state_bucket_access.arn
   }
 }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `modules/github_actions_role/main.tf` file. The change updates the `StateBucketAccess` policy to use the ARN from the `aws_iam_policy.state_bucket_access` resource instead of the `state_bucket_arn` variable.