### PR TITLE
Remove duplicated permissions

### DIFF
--- a/modules/ssvc_ci_role_eks_config/main.tf
+++ b/modules/ssvc_ci_role_eks_config/main.tf
@@ -43,10 +43,6 @@ data "aws_iam_policy_document" "this" {
   statement {
     effect = "Allow"
     actions = [
-      "ecr:GetRepositoryPolicy",
-      "ecr:GetLifecyclePolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListTagsForResource",
       "eks:DescribeCluster",
     ]
     resources = ["*"]


### PR DESCRIPTION
This pull request removes unused permissions from the IAM policy document in the `modules/ssvc_ci_role_eks_config/main.tf` file to improve security and reduce the scope of access.

### Security improvements:
* Removed the following unused `ecr` permissions from the IAM policy: `GetRepositoryPolicy`, `GetLifecyclePolicy`, `DescribeRepositories`, and `ListTagsForResource`. This reduces the scope of access to only the necessary `eks:DescribeCluster` action.