### PR TITLE
Create GitHubActionsAdministrator role

### DIFF
--- a/modules/github_actions_role/README.md
+++ b/modules/github_actions_role/README.md
@@ -20,18 +20,14 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.application_role_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.application_role_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_github_organization"></a> [github\_organization](#input\_github\_organization) | GitHub organization name for OIDC provider | `string` | n/a | yes |
-| <a name="input_state_bucket_arn"></a> [state\_bucket\_arn](#input\_state\_bucket\_arn) | ARN of the state bucket | `string` | n/a | yes |
+| <a name="input_github_repository"></a> [github\_repository](#input\_github\_repository) | GitHub repository name for OIDC provider | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/github_actions_role/main.tf
+++ b/modules/github_actions_role/main.tf
@@ -9,74 +9,13 @@ module "github_actions_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "5.55.0"
 
-  name = "GitHubActionsManagement"
+  name = "GitHubActionsAdministrator"
 
   subjects = [
-    "repo:${var.github_organization}/*",
+    "repo:${var.github_organization}/${var.github_repository}:*",
   ]
 
   policies = {
-    ApplicationRoleManagement = aws_iam_policy.application_role_management.arn
-    StateBucketAccess         = aws_iam_policy.state_bucket_access.arn
+    AdministratorAccess = "arn:aws:iam::aws:policy/AdministratorAccess"
   }
-}
-
-data "aws_iam_policy_document" "application_role_management" {
-  statement {
-    sid    = "AllowApplicationRoleManagement"
-    effect = "Allow"
-    actions = [
-      "iam:CreateRole",
-      "iam:DeleteRole",
-      "iam:GetRole",
-      "iam:PutRolePolicy",
-      "iam:DeleteRolePolicy",
-      "iam:AttachRolePolicy",
-      "iam:DetachRolePolicy",
-      "iam:TagRole",
-      "iam:ListRoleTags",
-      "iam:ListAttachedRolePolicies",
-      "iam:ListRolePolicies"
-    ]
-    resources = [
-      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/GitHubActionsApp*"
-    ]
-  }
-
-  statement {
-    sid    = "AllowIAMList"
-    effect = "Allow"
-    actions = [
-      "iam:List*"
-    ]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "application_role_management" {
-  name        = "ApplicationRoleManagement"
-  description = "Policy for managing application IAM roles for GitHub Actions"
-  policy      = data.aws_iam_policy_document.application_role_management.json
-}
-
-data "aws_iam_policy_document" "state_bucket_access" {
-  statement {
-    sid       = "AllowListBucket"
-    effect    = "Allow"
-    actions   = ["s3:ListBucket"]
-    resources = [var.state_bucket_arn]
-  }
-
-  statement {
-    sid       = "AllowStateBucketAccess"
-    effect    = "Allow"
-    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
-    resources = ["${var.state_bucket_arn}/*"]
-  }
-}
-
-resource "aws_iam_policy" "state_bucket_access" {
-  name        = "GitHubActionsStateBucketAccess"
-  description = "Policy to access Terraform state bucket"
-  policy      = data.aws_iam_policy_document.state_bucket_access.json
 }

--- a/modules/github_actions_role/variables.tf
+++ b/modules/github_actions_role/variables.tf
@@ -3,7 +3,7 @@ variable "github_organization" {
   type        = string
 }
 
-variable "state_bucket_arn" {
-  description = "ARN of the state bucket"
+variable "github_repository" {
+  description = "GitHub repository name for OIDC provider"
   type        = string
 }

--- a/modules/state_bucket/README.md
+++ b/modules/state_bucket/README.md
@@ -5,7 +5,9 @@ No requirements.
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
@@ -15,7 +17,10 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_iam_policy.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_document.state_bucket_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 

--- a/modules/state_bucket/main.tf
+++ b/modules/state_bucket/main.tf
@@ -23,3 +23,25 @@ module "tf_state_bucket" {
     role = "storage"
   }
 }
+
+data "aws_iam_policy_document" "state_bucket_access" {
+  statement {
+    sid       = "AllowListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [module.tf_state_bucket.s3_bucket_arn]
+  }
+
+  statement {
+    sid       = "AllowStateBucketAccess"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = ["${module.tf_state_bucket.s3_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_policy" "state_bucket_access" {
+  name        = "GitHubActionsStateBucketAccess"
+  description = "Policy to access Terraform state bucket"
+  policy      = data.aws_iam_policy_document.state_bucket_access.json
+}


### PR DESCRIPTION
This pull request refactors the Terraform modules for GitHub Actions and state bucket management. It simplifies the `github_actions_role` module by removing custom IAM policies and consolidates state bucket access policies into the `state_bucket` module. The most significant changes are grouped below:

### GitHub Actions Role Module Refactor:
* Removed custom IAM policies (`application_role_management` and `state_bucket_access`) and replaced them with the built-in `AdministratorAccess` policy in the `github_actions_role` module.
* Updated the module to use a specific GitHub repository (`github_repository`) instead of applying to all repositories in the organization. [[1]](diffhunk://#diff-a6fbcb9b2e696dddc0745cc82be4e2b50b6cbb3f6a3213cb97eb74a014882c1aL12-L82) [[2]](diffhunk://#diff-d2f7e76a6f95ec9af568f2540566aa5f800986db11f45bdc9383567ff05bd5d0L6-R7)

### State Bucket Module Enhancements:
* Added a new `aws_iam_policy` resource (`state_bucket_access`) and its corresponding `aws_iam_policy_document` data source to manage state bucket access policies directly in the `state_bucket` module.
* Updated the `README.md` for the `state_bucket` module to document the newly added provider and resources. [[1]](diffhunk://#diff-8d498636543a2cda106ad3b9e4c778bcf81ea6833579162a01e5a5488facfabfL8-R10) [[2]](diffhunk://#diff-8d498636543a2cda106ad3b9e4c778bcf81ea6833579162a01e5a5488facfabfL18-R23)

### Documentation Updates:
* Updated the `README.md` for the `github_actions_role` module to reflect the removal of custom IAM policies and the addition of the `github_repository` input variable.